### PR TITLE
Change input_dim to 1

### DIFF
--- a/model/STAEformer.py
+++ b/model/STAEformer.py
@@ -115,7 +115,7 @@ class STAEformer(nn.Module):
         in_steps=12,
         out_steps=12,
         steps_per_day=288,
-        input_dim=3,
+        input_dim=1,
         output_dim=1,
         input_embedding_dim=24,
         tod_embedding_dim=24,

--- a/model/STAEformer.yaml
+++ b/model/STAEformer.yaml
@@ -25,7 +25,7 @@ METRLA:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24
@@ -62,7 +62,7 @@ PEMSBAY:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24
@@ -100,7 +100,7 @@ PEMS04:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24
@@ -138,7 +138,7 @@ PEMS07:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24
@@ -176,7 +176,7 @@ PEMS08:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24
@@ -215,7 +215,7 @@ PEMS03:
     in_steps: 12
     out_steps: 12
     steps_per_day: 288
-    input_dim: 3
+    input_dim: 1
     output_dim: 1
     input_embedding_dim: 24
     tod_embedding_dim: 24


### PR DESCRIPTION
I noticed that the `input_dim` parameter in the STAEformer class as well as in the STAEformer.yaml is set to 3. However, in line 200 of STAEformer.py (`x = x[..., : self.input_dim]`) we extract everything from the input _up to_ `input_dim`, which would mean also the time of day and the day of week values. Afterwards we apply an input projection to `x`, which in the paper is only applied to the traffic volume. I believe `input_dim=1` would therefore be correct?